### PR TITLE
feat: add typst to eglot-ltex-plus-active-mode

### DIFF
--- a/eglot-ltex-plus.el
+++ b/eglot-ltex-plus.el
@@ -61,6 +61,7 @@ https://github.com/ltex-plus/ltex-ls-plus"
     (LaTeX-mode :language-id "latex") ;; AUCTeX
     (markdown-mode :language-id "markdown")
     (rst-mode :language-id "restructuredtext")
+    (typst-ts-mode :language-id "typst")
     (message-mode :language-id "plaintext")
     (mu4e-compose-mode :language-id "plaintext")
     (text-mode :language-id "plaintext"))


### PR DESCRIPTION
Hi, and thanks for maintaining this package.

This PR is just to add Typst support, which has been [added to ltex-ls-plus since 18.3.0 ](https://github.com/ltex-plus/ltex-ls-plus/releases/tag/18.3.0)

I've put the mode [`typst-ts-mode`](https://codeberg.org/meow_king/typst-ts-mode) because there's no  `typst-mode` package (without tree-sitter) in emacs that I know of. 